### PR TITLE
Esp fix and samples

### DIFF
--- a/examples/esp8266/simplesample_http/simplesample_http.c
+++ b/examples/esp8266/simplesample_http/simplesample_http.c
@@ -12,18 +12,7 @@ That does not mean that HTTP only works with the _LL APIs.
 Simply changing the using the convenience layer (functions not having _LL)
 and removing calls to _DoWork will yield the same results. */
 
-#ifdef ARDUINO
 #include "AzureIoT.h"
-#else
-#include "serializer.h"
-#include "iothub_client_ll.h"
-#include "iothubtransporthttp.h"
-#include "threadapi.h"
-#endif
-
-#ifdef MBED_BUILD_TIMESTAMP
-#include "certs.h"
-#endif // MBED_BUILD_TIMESTAMP
 
 static const char* connectionString = "HostName=[host].azure-devices.net;DeviceId=[device];SharedAccessKey=[key]";
 
@@ -78,17 +67,17 @@ static void sendMessage(IOTHUB_CLIENT_LL_HANDLE iotHubClientHandle, const unsign
     IOTHUB_MESSAGE_HANDLE messageHandle = IoTHubMessage_CreateFromByteArray(buffer, size);
     if (messageHandle == NULL)
     {
-        printf(PSTR("unable to create a new IoTHubMessage\r\n"));
+        LogInfo("unable to create a new IoTHubMessage\r\n");
     }
     else
     {
         if (IoTHubClient_LL_SendEventAsync(iotHubClientHandle, messageHandle, sendCallback, (void*)(uintptr_t)messageTrackingId) != IOTHUB_CLIENT_OK)
         {
-            printf(PSTR("failed to hand over the message to IoTHubClient"));
+            LogInfo("failed to hand over the message to IoTHubClient");
         }
         else
         {
-            printf(PSTR("IoTHubClient accepted the message for delivery\r\n"));
+            LogInfo("IoTHubClient accepted the message for delivery\r\n");
         }
         IoTHubMessage_Destroy(messageHandle);
     }
@@ -104,7 +93,7 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT IoTHubMessage(IOTHUB_MESSAGE_HANDLE mess
     size_t size;
     if (IoTHubMessage_GetByteArray(message, &buffer, &size) != IOTHUB_MESSAGE_OK)
     {
-        printf(PSTR("unable to IoTHubMessage_GetByteArray\r\n"));
+        LogInfo("unable to IoTHubMessage_GetByteArray\r\n");
         result = EXECUTE_COMMAND_ERROR;
     }
     else
@@ -113,7 +102,7 @@ static IOTHUBMESSAGE_DISPOSITION_RESULT IoTHubMessage(IOTHUB_MESSAGE_HANDLE mess
         char* temp = malloc(size + 1);
         if (temp == NULL)
         {
-            printf(PSTR("failed to malloc\r\n"));
+            LogInfo("failed to malloc\r\n");
             result = EXECUTE_COMMAND_ERROR;
         }
         else
@@ -152,7 +141,7 @@ void simplesample_http_run(void)
             unsigned int minimumPollingTime = 9; /*because it can poll "after 9 seconds" polls will happen effectively at ~10 seconds*/
             if (IoTHubClient_LL_SetOption(iotHubClientHandle, "MinimumPollingTime", &minimumPollingTime) != IOTHUB_CLIENT_OK)
             {
-                printf(PSTR("failure to set option \"MinimumPollingTime\"\r\n"));
+                LogInfo("failure to set option \"MinimumPollingTime\"\r\n");
             }
 
 #ifdef MBED_BUILD_TIMESTAMP
@@ -172,7 +161,7 @@ void simplesample_http_run(void)
             {
                 if (IoTHubClient_LL_SetMessageCallback(iotHubClientHandle, IoTHubMessage, myWeather) != IOTHUB_CLIENT_OK)
                 {
-                    printf(PSTR("unable to IoTHubClient_SetMessageCallback\r\n"));
+                    LogInfo("unable to IoTHubClient_SetMessageCallback\r\n");
                 }
                 else
                 {
@@ -190,17 +179,17 @@ void simplesample_http_run(void)
                             IOTHUB_MESSAGE_HANDLE messageHandle = IoTHubMessage_CreateFromByteArray(destination, destinationSize);
                             if (messageHandle == NULL)
                             {
-                                printf(PSTR("unable to create a new IoTHubMessage\r\n"));
+                                LogInfo("unable to create a new IoTHubMessage\r\n");
                             }
                             else
                             {
                                 if (IoTHubClient_LL_SendEventAsync(iotHubClientHandle, messageHandle, sendCallback, (void*)1) != IOTHUB_CLIENT_OK)
                                 {
-                                    printf(PSTR("failed to hand over the message to IoTHubClient"));
+                                    LogInfo("failed to hand over the message to IoTHubClient\r\n");
                                 }
                                 else
                                 {
-                                    printf(PSTR("IoTHubClient accepted the message for delivery\r\n"));
+                                    LogInfo("IoTHubClient accepted the message for delivery\r\n");
                                 }
 
                                 IoTHubMessage_Destroy(messageHandle);

--- a/examples/esp8266/simplesample_http/simplesample_http.ino
+++ b/examples/esp8266/simplesample_http/simplesample_http.ino
@@ -1,4 +1,4 @@
-// Please use an Arduino IDE 1.6.8 (once released)
+// Please use an Arduino IDE 1.6.8 or greater
 
 #include <ESP8266WiFi.h>
 #include <time.h>
@@ -21,9 +21,9 @@ void loop() {
 }
 
 void initSerial() {
-	// Start serial and initialize stdout
+    // Start serial and initialize stdout
     Serial.begin(115200);
-	Serial.setDebugOutput(true);
+    Serial.setDebugOutput(true);
 }
 
 void initWifi() {

--- a/examples/samd/README.md
+++ b/examples/samd/README.md
@@ -1,4 +1,3 @@
 These examples are ports from the [Microsoft Azure IoT device SDK for C](https://github.com/Azure/azure-iot-sdks/blob/master/c/readme.md).
 
- * [iothub_client_sample_http](iothub_client_sample_http) is from: https://github.com/Azure/azure-iot-sdks/tree/master/c/iothub_client/samples/iothub_client_sample_http
  * [simplesample_http](simplesample_http) is from: https://github.com/Azure/azure-iot-sdks/tree/master/c/serializer/samples/simplesample_http

--- a/examples/samd/simplesample_http/simplesample_http.c
+++ b/examples/samd/simplesample_http/simplesample_http.c
@@ -11,20 +11,9 @@ That does not mean that HTTP only works with the _LL APIs.
 Simply changing the using the convenience layer (functions not having _LL)
 and removing calls to _DoWork will yield the same results. */
 
-#ifdef ARDUINO
 #include "AzureIoT.h"
-#else
-#include "serializer.h"
-#include "iothub_client_ll.h"
-#include "iothubtransporthttp.h"
-#include "threadapi.h"
-#endif
 
-#ifdef MBED_BUILD_TIMESTAMP
-#include "certs.h"
-#endif // MBED_BUILD_TIMESTAMP
-
-static const char* connectionString = "[device connection string]";
+static const char* connectionString = "HostName=[host].azure-devices.net;DeviceId=[device];SharedAccessKey=[key]";
 
 // Define the Model
 BEGIN_NAMESPACE(WeatherStation);

--- a/examples/samd/simplesample_http/simplesample_http.ino
+++ b/examples/samd/simplesample_http/simplesample_http.ino
@@ -79,6 +79,7 @@ void initWifi() {
             delay(10000);
         }
     }
+    
     Serial.println("Connected to wifi");
 }
 
@@ -106,8 +107,8 @@ void initTime() {
             break;
         }
     }
+    
     ntpClient.end();
-
 
     struct timeval tv;
     tv.tv_sec = epochTime;

--- a/src/esp8266/azcpgmspace.cpp
+++ b/src/esp8266/azcpgmspace.cpp
@@ -1,0 +1,9 @@
+#include "azcpgmspace.h"
+
+char* az_c_strncpy_P(char* dest, PGM_P src, size_t size) {
+    return strncpy_P(dest, src, size);
+}
+
+size_t az_c_strlen_P(PGM_P s) {
+    return strlen_P(s);
+}

--- a/src/esp8266/azcpgmspace.cpp
+++ b/src/esp8266/azcpgmspace.cpp
@@ -1,3 +1,4 @@
+#if defined(ARDUINO_ARCH_ESP8266)
 #include "azcpgmspace.h"
 
 char* az_c_strncpy_P(char* dest, PGM_P src, size_t size) {
@@ -7,3 +8,4 @@ char* az_c_strncpy_P(char* dest, PGM_P src, size_t size) {
 size_t az_c_strlen_P(PGM_P s) {
     return strlen_P(s);
 }
+#endif

--- a/src/esp8266/azcpgmspace.h
+++ b/src/esp8266/azcpgmspace.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/** @file azcpgmspace.h
+*	@brief Function prototypes for pgmspace functions that need extern-ing to C
+*
+*	@details These fucntions are just wrappers around existing ones in pgmspace.h that
+*    are not defined in a way to make them linkable from c libs.
+*/
+#ifndef _CPGMSPACE_H
+#define _CPGMSPACE_H
+
+#include <pgmspace.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+char* az_c_strncpy_P(char* dest, PGM_P src, size_t size);
+size_t az_c_strlen_P(PGM_P s);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/esp8266/azcpgmspace.h
+++ b/src/esp8266/azcpgmspace.h
@@ -7,8 +7,9 @@
 *	@details These fucntions are just wrappers around existing ones in pgmspace.h that
 *    are not defined in a way to make them linkable from c libs.
 */
-#ifndef _CPGMSPACE_H
-#define _CPGMSPACE_H
+#if defined(ARDUINO_ARCH_ESP8266)
+#ifndef _AZCPGMSPACE_H
+#define _AZCPGMSPACE_H
 
 #include <pgmspace.h>
 
@@ -21,4 +22,6 @@ size_t az_c_strlen_P(PGM_P s);
 }
 #endif
 
-#endif
+#endif // _AZCPGMSPACE_H
+
+#endif // #if defined(ARDUINO_ARCH_ESP8266)

--- a/src/iot_logging.h
+++ b/src/iot_logging.h
@@ -10,10 +10,36 @@ in a later revision.
 */
 
 #if defined(ARDUINO_ARCH_ESP8266)
-#include <pgmspace.h>
-#define LogUsage(FORMAT, ...) (void)os_printf(PSTR(FORMAT), ##__VA_ARGS__);
-#define LogInfo(FORMAT, ...) (void)os_printf(PSTR(FORMAT), ##__VA_ARGS__);
-#define LogError(FORMAT, ...) (void)os_printf(PSTR(FORMAT), ##__VA_ARGS__);
+#include "esp8266/azcpgmspace.h"
+#define LogUsage(FORMAT, ...) { \
+        const char* __localFORMAT = PSTR(FORMAT); \
+        size_t __localFORMATSIZE = az_c_strlen_P(__localFORMAT) + 1; \
+        char* __localREALSTR = (char*)malloc(__localFORMATSIZE * sizeof(char)); \
+        __localREALSTR[__localFORMATSIZE-1] = '\0'; \
+        az_c_strncpy_P(__localREALSTR, __localFORMAT, __localFORMATSIZE); \
+        os_printf(__localREALSTR, ##__VA_ARGS__); \
+        free(__localREALSTR); \
+}
+#define LogInfo(FORMAT, ...) { \
+        const char* __localFORMAT = PSTR(FORMAT); \
+        size_t __localFORMATSIZE = az_c_strlen_P(__localFORMAT) + 1; \
+        char* __localREALSTR = (char*)malloc(__localFORMATSIZE * sizeof(char)); \
+        __localREALSTR[__localFORMATSIZE-1] = '\0'; \
+        az_c_strncpy_P(__localREALSTR, __localFORMAT, __localFORMATSIZE); \
+        os_printf(__localREALSTR, ##__VA_ARGS__); \
+        free(__localREALSTR); \
+}
+
+#define LogError(FORMAT, ...) { \
+        const char* __localFORMAT = PSTR(FORMAT); \
+        size_t __localFORMATSIZE = az_c_strlen_P(__localFORMAT) + 1; \
+        char* __localREALSTR = (char*)malloc(__localFORMATSIZE * sizeof(char)); \
+        __localREALSTR[__localFORMATSIZE-1] = '\0'; \
+        az_c_strncpy_P(__localREALSTR, __localFORMAT, __localFORMATSIZE); \
+        os_printf(__localREALSTR, ##__VA_ARGS__); \
+        free(__localREALSTR); \
+}
+
 #elif defined(ARDUINO_ARCH_SAMD)
 #define LogUsage (void)printf
 #define LogInfo(...) (void)printf("Info: " __VA_ARGS__)


### PR DESCRIPTION
It seemed that the PSTR macro resulted in addresses that were usable by os_printf on windows but were not reliably useful when building on mac/linux :confused: To fix that this change updates the logging defines for esp to use PSTR to save space but manually unpack it in a more reliable way. I've tested this with the latest (from source) esp board config on the esp8266 thing dev and feather huzzah esp8266 as well as ensured it still built and worked for the feather m0 and built for arduino zero.

Other changes in this PR include some sample cleanup for dead code and stuff.
